### PR TITLE
chore: readme should use launch command for automated cluster

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -30,7 +30,7 @@ dbx execute --cluster-name=<name of interactive cluster> --job={{cookiecutter.pr
 
 For a test on a automated job cluster, use `launch` instead of `execute`:
 ```
-dbx execute --job={{cookiecutter.project_name}}-sample-integration-test
+dbx launch --job={{cookiecutter.project_name}}-sample-integration-test
 ```
 
 ## Interactive execution and development


### PR DESCRIPTION
Based on issue #39. Minor update to the docs where the command in the example snippet should be `launch` instead of `execute`.