### PR TITLE
fixed Azure DevOps pipeline

### DIFF
--- a/{{cookiecutter.project_slug}}/azure-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/azure-pipelines.yml
@@ -12,10 +12,6 @@ trigger:
       - v*.*
       - prod
 
-  paths:
-    exclude:
-      - mlruns/*
-
 stages:
 - stage: onPush
   jobs:

--- a/{{cookiecutter.project_slug}}/azure-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/azure-pipelines.yml
@@ -14,7 +14,6 @@ trigger:
 
   paths:
     exclude:
-      - .github/*
       - mlruns/*
 
 stages:

--- a/{{cookiecutter.project_slug}}/azure-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+- group: Databricks-environment
+
 trigger:
   batch: true
   branches:
@@ -8,6 +11,11 @@ trigger:
     include:
       - v*.*
       - prod
+
+  paths:
+    exclude:
+      - .github/*
+      - mlruns/*
 
 stages:
 - stage: onPush


### PR DESCRIPTION
This is a fix for Azure Devops, as it needs variables to pass the DATABRICKS_HOST and DATABRICKS_TOKEN variables from Azure Devops to the running pipeline.