### PR TITLE
Gitlab Integration Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ This repository provides a template for automated Databricks CI/CD pipeline crea
   * [CLI example](#cli-example)
   * [Sample project structure (with GitHub Actions)](#sample-project-structure-with-github-actions)
   * [Sample project structure (with Azure DevOps)](#sample-project-structure-with-azure-devops)
+  * [Sample project structure (with GitLab)](##sample-project-structure-with-gitlab)
   * [Quickstart](#quickstart)
      * [Local steps](#local-steps)
      * [Setting up CI/CD pipeline on GitHub Actions](#setting-up-cicd-pipeline-on-github-actions)
      * [Setting up CI/CD pipeline on Azure DevOps](#setting-up-cicd-pipeline-on-azure-devops)
+     * [Setting up CI/CD pipeline on GitLab](##setting-up-cicd-pipeline-on-gitlab)
   * [Deployment file structure](#deployment-file-structure)
   * [FAQ](#faq)
   * [Legal Information](#legal-information)
@@ -101,6 +103,45 @@ Some explanations regarding structure:
 - `conf/deployment.json` - deployment configuration file. Please read the [following section](#deployment-file-structure) for a full reference.
 - `azure-pipelines.yml` - Azure DevOps Pipelines workflow definition
 
+## Sample project structure (with GitLab)
+```
+.
+├── .dbx
+│   └── project.json
+├── .gitignore
+├── README.md
+├── .gitlab-ci.yml
+├── conf
+│   ├── deployment.json
+│   └── test
+│       └── sample.json
+├── pytest.ini
+├── sample_project_gitlab
+│   ├── __init__.py
+│   ├── common.py
+│   └── jobs
+│       ├── __init__.py
+│       └── sample
+│           ├── __init__.py
+│           └── entrypoint.py
+├── setup.py
+├── tests
+│   ├── integration
+│   │   └── sample_test.py
+│   └── unit
+│       └── sample_test.py
+├── tools
+│   └── dbx-0.7.0-py3-none-any.whl
+└── unit-requirements.txt
+```
+
+Some explanations regarding structure:
+- `.dbx` folder is an auxiliary folder, where metadata about environments and execution context is located.
+- `sample_project_gitlab` - Python package with your code (the directory name will follow your project name)
+- `tests` - directory with your package tests
+- `conf/deployment.json` - deployment configuration file. Please read the [following section](#deployment-file-structure) for a full reference.
+- `.gitlab-ci.yml` - GitLab CI/CD workflow definition
+
 ## Quickstart
 
 > **_NOTE:_**  
@@ -158,6 +199,15 @@ dbx launch --job <your-job-name> --trace
 - Add a remote origin to the local repo
 - Push the code 
 - Open the Azure DevOps UI to check the deployment status 
+
+### Setting up CI/CD pipeline on Gitlab
+
+- Create a new repository on Gitlab
+- Configure `DATABRICKS_HOST` and `DATABRICKS_TOKEN` secrets for your project in [GitLab UI](https://docs.gitlab.com/ee/ci/variables/#create-a-custom-variable-in-the-ui)
+- Add a remote origin to the local repo
+- Push the code 
+- Open the GitLab CI/CD UI to check the deployment status 
+
  
 ## Deployment file structure
 A sample deployment file could be found in a generated project.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,7 +9,8 @@
   ],
   "cicd_tool": [
     "GitHub Actions",
-    "Azure DevOps"
+    "Azure DevOps",
+    "GitLab"
   ],
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "workspace_dir": "/Shared/dbx/{{cookiecutter.project_slug}}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -142,12 +142,18 @@ class PostProcessor:
 
         if cicd_tool == 'GitHub Actions':
             os.remove("azure-pipelines.yml")
+            os.remove(".gitlab-ci.yml")
 
             replace_vars(".github/workflows/onpush.yml")
             replace_vars(".github/workflows/onrelease.yml")
 
         if cicd_tool == 'Azure DevOps':
             shutil.rmtree(".github")
+            os.remove(".gitlab-ci.yml")
+
+        if cicd_tool == 'GitLab':
+            shutil.rmtree(".github")
+            os.remove("azure-pipelines.yml")
 
         deployment = json.dumps(DEPLOYMENT[cloud], indent=4)
         deployment_file = Path("conf/deployment.json")

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -25,7 +25,7 @@ integration-testing:
     - pip install -U tools/dbx-0.7.0-py3-none-any.whl
     - pip install -e .
     - echo "Preparing profile"
-    - echo "[DEFAULT]" >> ~/.databrickscfg
+    - echo "[{{cookiecutter.profile}}]" >> ~/.databrickscfg
     - echo "host = $DATABRICKS_HOST" >> ~/.databrickscfg
     - echo "token = $DATABRICKS_TOKEN" >> ~/.databrickscfg
     - echo "Deploying tests"
@@ -45,7 +45,7 @@ deployment:
     - pip install -U tools/dbx-0.7.0-py3-none-any.whl
     - pip install -e .
     - echo "Preparing profile"
-    - echo "[DEFAULT]" >> ~/.databrickscfg
+    - echo "[{{cookiecutter.profile}}]" >> ~/.databrickscfg
     - echo "host = $DATABRICKS_HOST" >> ~/.databrickscfg
     - echo "token = $DATABRICKS_TOKEN" >> ~/.databrickscfg
     - echo "Deploying Job"

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+stages:
+    - unit-testing
+    - integration-testing
+    - deployment
+
+unit-testing:
+  stage: unit-testing
+  image: python:3.7-stretch
+  script:
+    - echo "Install dependencies"
+    - apt-get update
+    - apt-get install default-jdk -y
+    - pip install -r unit-requirements.txt
+    - pip install -U tools/dbx-0.7.0-py3-none-any.whl
+    - pip install -e .
+    - echo "Launching unit tests"
+    - pytest tests/unit
+
+integration-testing:
+  stage: integration-testing
+  image: python:3.7-stretch
+  script:
+    - echo "Install dependencies"
+    - pip install -r unit-requirements.txt
+    - pip install -U tools/dbx-0.7.0-py3-none-any.whl
+    - pip install -e .
+    - echo "Preparing profile"
+    - echo "[DEFAULT]" >> ~/.databrickscfg
+    - echo "host = $DATABRICKS_HOST" >> ~/.databrickscfg
+    - echo "token = $DATABRICKS_TOKEN" >> ~/.databrickscfg
+    - echo "Deploying tests"
+    - dbx deploy --jobs={project_name}-integration-test
+    - echo "Running tests"
+    - dbx launch --job={project_name}-integration-test --trace
+
+deployment:
+  stage: deployment
+  image: python:3.7-stretch
+  only:
+    refs:
+      - master
+  script:
+    - echo "Install dependencies"
+    - pip install -r unit-requirements.txt
+    - pip install -U tools/dbx-0.7.0-py3-none-any.whl
+    - pip install -e .
+    - echo "Preparing profile"
+    - echo "[DEFAULT]" >> ~/.databrickscfg
+    - echo "host = $DATABRICKS_HOST" >> ~/.databrickscfg
+    - echo "token = $DATABRICKS_TOKEN" >> ~/.databrickscfg
+    - echo "Deploying Job"
+    - dbx deploy --jobs={project_name}-sample


### PR DESCRIPTION
Adding gitlab_ci yml file which will extend the porject support to Gitlab CI-CD
The idea is: 
1. On every push to all branches we run unit-tests and integration tests
2. On push to master we deploy the actual job along with running all tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databrickslabs/cicd-templates/48)
<!-- Reviewable:end -->
