### PR TITLE
Use pathlib instead of path module

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,7 +2,7 @@ import json
 import os
 import shutil
 
-from path import Path
+from phathlib import Path
 
 cicd_tool = '{{cookiecutter.cicd_tool}}'
 cloud = '{{cookiecutter.cloud}}'


### PR DESCRIPTION
Required for newer versions of python, will probably drop support for older pythons.